### PR TITLE
Increased PotionAbility duration check to 15 seconds

### DIFF
--- a/src/main/java/mchorse/vanilla_pack/abilities/NightVision.java
+++ b/src/main/java/mchorse/vanilla_pack/abilities/NightVision.java
@@ -12,6 +12,5 @@ public class NightVision extends PotionAbility
     public NightVision()
     {
         this.potion = MobEffects.NIGHT_VISION;
-        this.duration = 2400;
     }
 }

--- a/src/main/java/mchorse/vanilla_pack/abilities/PotionAbility.java
+++ b/src/main/java/mchorse/vanilla_pack/abilities/PotionAbility.java
@@ -4,7 +4,6 @@ import mchorse.metamorph.api.abilities.Ability;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.IntegerCache;
 
 /**
  * Abstract potion ability

--- a/src/main/java/mchorse/vanilla_pack/abilities/PotionAbility.java
+++ b/src/main/java/mchorse/vanilla_pack/abilities/PotionAbility.java
@@ -4,6 +4,7 @@ import mchorse.metamorph.api.abilities.Ability;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.IntegerCache;
 
 /**
  * Abstract potion ability
@@ -14,7 +15,7 @@ import net.minecraft.potion.PotionEffect;
 public abstract class PotionAbility extends Ability
 {
     protected Potion potion;
-    protected int duration = 1200;
+    protected int duration = Integer.MAX_VALUE;
 
     @Override
     public void update(EntityLivingBase target)

--- a/src/main/java/mchorse/vanilla_pack/abilities/PotionAbility.java
+++ b/src/main/java/mchorse/vanilla_pack/abilities/PotionAbility.java
@@ -15,14 +15,14 @@ import net.minecraft.util.IntegerCache;
 public abstract class PotionAbility extends Ability
 {
     protected Potion potion;
-    protected int duration = Integer.MAX_VALUE;
+    protected int duration = 1200;
 
     @Override
     public void update(EntityLivingBase target)
     {
         PotionEffect effect = target.getActivePotionEffect(this.potion);
 
-        if (effect.getDuration() < 5)
+        if (effect == null || effect.getDuration() < 300)
         {
             this.onDemorph(target);
             this.onMorph(target);


### PR DESCRIPTION
This raises the potion duration check to look for any duration less than 300 ticks or if the effect is currently not applied at all incase another mod or effect had stripped it early.

This fixes #33 as well as a potential NPE.