### PR TITLE
[1.10] More event hooks and morph "healing" fix

### DIFF
--- a/src/main/java/mchorse/metamorph/api/MorphAPI.java
+++ b/src/main/java/mchorse/metamorph/api/MorphAPI.java
@@ -49,7 +49,7 @@ public class MorphAPI
             return false;
         }
 
-        MorphEvent event = new MorphEvent(player, morph, force);
+        MorphEvent.Pre event = new MorphEvent.Pre(player, morph, force);
 
         if (MinecraftForge.EVENT_BUS.post(event))
         {
@@ -62,6 +62,10 @@ public class MorphAPI
         {
             Dispatcher.sendTo(new PacketMorph(morph), (EntityPlayerMP) player);
             Dispatcher.updateTrackers(player, new PacketMorphPlayer(player.getEntityId(), morph));
+        }
+        
+        if (morphed) {
+            MinecraftForge.EVENT_BUS.post(new MorphEvent.Post(player, event.morph, force));
         }
 
         return morphed;
@@ -80,7 +84,7 @@ public class MorphAPI
             return false;
         }
 
-        AcquireMorphEvent event = new AcquireMorphEvent(player, morph);
+        AcquireMorphEvent.Pre event = new AcquireMorphEvent.Pre(player, morph);
 
         if (MinecraftForge.EVENT_BUS.post(event))
         {
@@ -88,10 +92,15 @@ public class MorphAPI
         }
 
         boolean acquired = Morphing.get(player).acquireMorph(event.morph);
-
+        
         if (!player.worldObj.isRemote && acquired)
         {
             Dispatcher.sendTo(new PacketAcquireMorph(event.morph), (EntityPlayerMP) player);
+        }
+        
+        if (acquired)
+        {
+            MinecraftForge.EVENT_BUS.post(new AcquireMorphEvent.Post(player, event.morph));
         }
 
         return acquired;

--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -22,6 +22,7 @@ import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
+import net.minecraftforge.fml.relauncher.Side;
 
 /**
  * Server event handler
@@ -59,6 +60,19 @@ public class MorphHandler
         IMorphing capability = Morphing.get(player);
 
         this.runFutureTasks(player);
+        
+        // A sanity check to prevent "healing" health when morphing to and from a mob with essentially zero health
+        // We have to do it every tick because you never know when another mod could change the max health
+        if (capability != null)
+        {
+            // If the current health ratio makes sense, store that ratio in the capability
+            float maxHealth = player.getMaxHealth();
+            if (maxHealth > IMorphing.REASONABLE_HEALTH_VALUE) {
+                float healthRatio = player.getHealth() / maxHealth;
+                capability.setLastHealthRatio(healthRatio);
+            }
+            
+        }
 
         if (capability == null || !capability.isMorphed())
         {

--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -149,7 +149,7 @@ public class MorphHandler
 
         if (!Metamorph.proxy.config.prevent_ghosts || !capability.acquiredMorph(morph))
         {
-            SpawnGhostEvent spawnGhostEvent = new SpawnGhostEvent(player, morph);
+            SpawnGhostEvent spawnGhostEvent = new SpawnGhostEvent.Pre(player, morph);
             if (MinecraftForge.EVENT_BUS.post(spawnGhostEvent) || spawnGhostEvent.morph == null)
             {
             	return;
@@ -160,6 +160,8 @@ public class MorphHandler
 
             morphEntity.setPositionAndRotation(target.posX, target.posY + target.height / 2, target.posZ, target.rotationYaw, target.rotationPitch);
             player.worldObj.spawnEntityInWorld(morphEntity);
+            
+            MinecraftForge.EVENT_BUS.post(new SpawnGhostEvent.Post(player, morph));
         }
     }
 

--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import mchorse.metamorph.Metamorph;
+import mchorse.metamorph.api.events.SpawnGhostEvent;
 import mchorse.metamorph.api.morphs.AbstractMorph;
 import mchorse.metamorph.capabilities.morphing.IMorphing;
 import mchorse.metamorph.capabilities.morphing.Morphing;
@@ -13,6 +14,7 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -133,7 +135,14 @@ public class MorphHandler
 
         if (!Metamorph.proxy.config.prevent_ghosts || !capability.acquiredMorph(morph))
         {
-            EntityMorph morphEntity = new EntityMorph(player.worldObj, player.getUniqueID(), morph);
+            SpawnGhostEvent spawnGhostEvent = new SpawnGhostEvent(player, morph);
+            if (MinecraftForge.EVENT_BUS.post(spawnGhostEvent) || spawnGhostEvent.morph == null)
+            {
+            	return;
+            }
+            morph = spawnGhostEvent.morph;
+            
+        	EntityMorph morphEntity = new EntityMorph(player.worldObj, player.getUniqueID(), morph);
 
             morphEntity.setPositionAndRotation(target.posX, target.posY + target.height / 2, target.posZ, target.rotationYaw, target.rotationPitch);
             player.worldObj.spawnEntityInWorld(morphEntity);

--- a/src/main/java/mchorse/metamorph/api/events/AcquireMorphEvent.java
+++ b/src/main/java/mchorse/metamorph/api/events/AcquireMorphEvent.java
@@ -9,7 +9,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 /**
  * Acquire morph event
  * 
- * This event is fired when a player is about to acquire a morph. This is not 
+ * {@link AcquireMorphEvent.Pre} is fired when a player is about to acquire a morph. This is not 
  * necessarily means that player already has this morph. Use {@link #hasMorph()} 
  * method to figure out whether player already has given morph.
  * 
@@ -18,8 +18,9 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * 
  * If you cancel this event, player won't acquire a morph, however, if player 
  * already has this morph, it will be completely useless.
+ * 
+ * {@link AcquireMorphEvent.Post} is fired after a player successfully acquires a new morph.
  */
-@Cancelable
 public class AcquireMorphEvent extends Event
 {
     public EntityPlayer player;
@@ -37,5 +38,20 @@ public class AcquireMorphEvent extends Event
     public boolean hasMorph()
     {
         return Morphing.get(this.player).acquiredMorph(this.morph);
+    }
+    
+    @Cancelable
+    public static class Pre extends AcquireMorphEvent
+    {
+        public Pre(EntityPlayer player, AbstractMorph morph) {
+            super(player, morph);
+        }
+    }
+    
+    public static class Post extends AcquireMorphEvent
+    {
+        public Post(EntityPlayer player, AbstractMorph morph) {
+            super(player, morph);
+        }
     }
 }

--- a/src/main/java/mchorse/metamorph/api/events/MorphEvent.java
+++ b/src/main/java/mchorse/metamorph/api/events/MorphEvent.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 /**
  * Morph event
  * 
- * This event occurs when player gets morphed or demorphed. If player gets 
+ * {@link MorphEvent.Pre} occurs when player gets morphed or demorphed. If player gets 
  * demorphed then {@link #morph} is null. Check for player's worldObj property 
  * to get on which side this event is triggered.
  * 
@@ -19,8 +19,9 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * You can also modify {@link #force} parameter which is responsible for 
  * forcing morphing (if not forced, player will morph only in case if he has 
  * acquired morph like given).
+ * 
+ * {@link MorphEvent.Post} is fired after a player successfully morphs or demorphs.
  */
-@Cancelable
 public class MorphEvent extends Event
 {
     public EntityPlayer player;
@@ -40,5 +41,20 @@ public class MorphEvent extends Event
     public boolean isDemorphing()
     {
         return this.morph == null;
+    }
+    
+    @Cancelable
+    public static class Pre extends MorphEvent
+    {
+        public Pre(EntityPlayer player, AbstractMorph morph, boolean force) {
+            super(player, morph, force);
+        }
+    }
+    
+    public static class Post extends MorphEvent
+    {
+        public Post(EntityPlayer player, AbstractMorph morph, boolean force) {
+            super(player, morph, force);
+        }
     }
 }

--- a/src/main/java/mchorse/metamorph/api/events/SpawnGhostEvent.java
+++ b/src/main/java/mchorse/metamorph/api/events/SpawnGhostEvent.java
@@ -1,0 +1,36 @@
+package mchorse.metamorph.api.events;
+
+import mchorse.metamorph.api.morphs.AbstractMorph;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Morph spawn event
+ * 
+ * This event occurs when a player kills a monster and a ghost is
+ * about to spawn from it. The event will not occur if the config option
+ * prevent_kill_acquire is set to true, nor will it occur if the config option
+ * prevent_ghosts is set to true while the player already has the morph.
+ * 
+ * {@link #player} is the player responsible for killing the monster which spawned
+ * the morph.
+ * 
+ * {@link #morph} is an instance of (@link #AbstractMorph} which represents the
+ * monster that was just killed. If you change this, a different morph ghost will
+ * spawn. If you set this to null, no morph will spawn.
+ * 
+ * Canceling this event will prevent the ghost from spawning.
+ */
+@Cancelable
+public class SpawnGhostEvent extends Event
+{
+	public EntityPlayer player;
+	public AbstractMorph morph;
+	
+	public SpawnGhostEvent(EntityPlayer player, AbstractMorph morph)
+	{
+		this.player = player;
+		this.morph = morph;
+	}
+}

--- a/src/main/java/mchorse/metamorph/api/events/SpawnGhostEvent.java
+++ b/src/main/java/mchorse/metamorph/api/events/SpawnGhostEvent.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 /**
  * Morph spawn event
  * 
- * This event occurs when a player kills a monster and a ghost is
+ * {@link SpawnGhostEvent.Pre} occurs when a player kills a monster and a ghost is
  * about to spawn from it. The event will not occur if the config option
  * prevent_kill_acquire is set to true, nor will it occur if the config option
  * prevent_ghosts is set to true while the player already has the morph.
@@ -20,9 +20,10 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * monster that was just killed. If you change this, a different morph ghost will
  * spawn. If you set this to null, no morph will spawn.
  * 
- * Canceling this event will prevent the ghost from spawning.
+ * Canceling the event will prevent the ghost from spawning.
+ * 
+ * {@link SpawnGhostEvent.Post} is fired after the ghost successfully spawns.
  */
-@Cancelable
 public class SpawnGhostEvent extends Event
 {
 	public EntityPlayer player;
@@ -32,5 +33,20 @@ public class SpawnGhostEvent extends Event
 	{
 		this.player = player;
 		this.morph = morph;
+	}
+	
+	@Cancelable
+	public static class Pre extends SpawnGhostEvent
+	{
+        public Pre(EntityPlayer player, AbstractMorph morph) {
+            super(player, morph);
+        }
+	}
+	
+	public static class Post extends SpawnGhostEvent
+	{
+        public Post(EntityPlayer player, AbstractMorph morph) {
+            super(player, morph);
+        }
 	}
 }

--- a/src/main/java/mchorse/metamorph/capabilities/morphing/IMorphing.java
+++ b/src/main/java/mchorse/metamorph/capabilities/morphing/IMorphing.java
@@ -13,6 +13,8 @@ import net.minecraft.entity.player.EntityPlayer;
  */
 public interface IMorphing
 {
+    public static final float REASONABLE_HEALTH_VALUE = Float.MIN_VALUE*100;
+    
     /**
      * Add a morph
      */
@@ -80,4 +82,14 @@ public interface IMorphing
      * Copy data from other morph 
      */
     public void copy(IMorphing morphing, EntityPlayer player);
+    
+    /**
+     * Get the last recorded finite health fraction of the player
+     */
+    public float getLastHealthRatio();
+    
+    /**
+     * Determines what the player's new health will be if the player morphs out of a morph with very low health
+     */
+    public void setLastHealthRatio(float lastHealthRatio);
 }

--- a/src/main/java/mchorse/metamorph/capabilities/morphing/Morphing.java
+++ b/src/main/java/mchorse/metamorph/capabilities/morphing/Morphing.java
@@ -29,6 +29,12 @@ public class Morphing implements IMorphing
      * Current used morph
      */
     private AbstractMorph morph;
+    
+    /**
+     * (health / max health) is stored here when the new max health ends up
+     * very close to zero, and retrieved when the fraction is meaningful again
+     */
+    private float lastHealthRatio;
 
     public static IMorphing get(EntityPlayer player)
     {
@@ -202,5 +208,17 @@ public class Morphing implements IMorphing
         this.acquiredMorphs = morphing.getAcquiredMorphs();
         this.setCurrentMorph(morphing.getCurrentMorph(), player, true);
         this.setFavorites(morphing.getFavorites());
+    }
+
+    @Override
+    public float getLastHealthRatio()
+    {
+        return lastHealthRatio;
+    }
+
+    @Override
+    public void setLastHealthRatio(float lastHealthRatio)
+    {
+        this.lastHealthRatio = lastHealthRatio;
     }
 }

--- a/src/main/java/mchorse/metamorph/capabilities/morphing/MorphingStorage.java
+++ b/src/main/java/mchorse/metamorph/capabilities/morphing/MorphingStorage.java
@@ -7,6 +7,7 @@ import mchorse.metamorph.api.MorphManager;
 import mchorse.metamorph.api.morphs.AbstractMorph;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagFloat;
 import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.EnumFacing;
@@ -30,6 +31,7 @@ public class MorphingStorage implements IStorage<IMorphing>
         NBTTagCompound tag = new NBTTagCompound();
         NBTTagList acquired = new NBTTagList();
         NBTTagList favorites = new NBTTagList();
+        tag.setTag("lastHealthRatio", new NBTTagFloat(instance.getLastHealthRatio()));
 
         if (instance.getCurrentMorph() != null)
         {
@@ -67,6 +69,7 @@ public class MorphingStorage implements IStorage<IMorphing>
             NBTTagList acquired = tag.getTagList("Morphs", 10);
             NBTTagList favorites = tag.getTagList("Favorites", 3);
             NBTTagCompound morphTag = tag.getCompoundTag("Morph");
+            instance.setLastHealthRatio(tag.getFloat("lastHealthRatio"));
 
             if (!tag.hasNoTags())
             {


### PR DESCRIPTION
Adds a new event hook for morph ghost spawns, and separates all cancelable events into a Pre-event which can be canceled and a Post-event which occurs only after the corresponding action occurred successfully.

Included also is a fix for a new bug that occurs with ToughAsNails installed and difficulty set to Hard, which only surfaces with the upcoming Forge build (to succeed 12.18.3.2422). With the upcoming Forge build, morphing into a chicken should no longer kill you, however, morphing back into a mob with higher health would result in your HP being reset to full regardless of how much HP you had before you morphed.  The fix I have given records the HP ratio that the player had before they morphed, to prevent using morphs to cheese heal.

I can PR these changes to other branches as needed.