### PR TITLE
Add config to disable morphs labeled 'hostile' avoiding attacks

### DIFF
--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -201,7 +201,8 @@ public class MorphHandler
     @SubscribeEvent
     public void onLivingSetAttackTarget(LivingSetAttackTargetEvent event)
     {
-        if (Metamorph.proxy.config.disable_morph_disguise) {
+        if (Metamorph.proxy.config.disable_morph_disguise)
+        {
             return;
         }
         

--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -201,6 +201,10 @@ public class MorphHandler
     @SubscribeEvent
     public void onLivingSetAttackTarget(LivingSetAttackTargetEvent event)
     {
+        if (Metamorph.proxy.config.disable_morph_disguise) {
+            return;
+        }
+        
         Entity target = event.getTarget();
         EntityLivingBase source = event.getEntityLiving();
 

--- a/src/main/java/mchorse/metamorph/config/MetamorphConfig.java
+++ b/src/main/java/mchorse/metamorph/config/MetamorphConfig.java
@@ -56,6 +56,12 @@ public class MetamorphConfig
      * Disables morphing animation 
      */
     public boolean disable_morph_animation;
+    
+    /**
+     * Disable the ability of morphs labeled as "hostile" to avoid being
+     * attacked by hostile mobs.
+     */
+    public boolean disable_morph_disguise;
 
     /* End of config options */
 
@@ -86,6 +92,7 @@ public class MetamorphConfig
         this.disable_pov = this.config.getBoolean("disable_pov", cat, false, "Disable modifying Point-of-View. Requested to fix MorePlayerModels vertical jittering", lang + "disable_pov");
         this.disable_health = this.config.getBoolean("disable_health", cat, false, "Disable modifying health. Requested to fix dying all the time with Tough as Nails", lang + "disable_health");
         this.disable_morph_animation = this.config.getBoolean("disable_morph_animation", cat, false, "Disables morphing animation", lang + "disable_morph_animation");
+        this.disable_morph_disguise = this.config.getBoolean("disable_morph_disguise", cat, false, "Disables the ability of morphs labeled as 'hostile' to avoid being attacked by hostile mobs.", lang + "disable_morph_disguise");
 
         this.config.getCategory(cat).setComment("General configuration of Metamorph mod");
 


### PR DESCRIPTION
This prevents Metamorph from conflicting with my AI-based method of handling how mobs attack morphs. :D