### PR TITLE
added config to disable metamorph gui

### DIFF
--- a/src/main/java/mchorse/metamorph/client/KeyboardHandler.java
+++ b/src/main/java/mchorse/metamorph/client/KeyboardHandler.java
@@ -3,6 +3,7 @@ package mchorse.metamorph.client;
 import org.lwjgl.input.Keyboard;
 
 import mchorse.metamorph.ClientProxy;
+import mchorse.metamorph.Metamorph;
 import mchorse.metamorph.capabilities.morphing.IMorphing;
 import mchorse.metamorph.capabilities.morphing.Morphing;
 import mchorse.metamorph.client.gui.GuiCreativeMenu;
@@ -101,7 +102,10 @@ public class KeyboardHandler
 
         if (keyCreativeMenu.isPressed() && mc.player.isCreative())
         {
-            mc.displayGuiScreen(new GuiCreativeMenu());
+        	//added
+        	if(!Metamorph.proxy.config.disable_gui_open){
+        		mc.displayGuiScreen(new GuiCreativeMenu());
+        	}
         }
 
         if (ClientProxy.getGameMode(mc.player) == GameType.ADVENTURE)
@@ -112,7 +116,10 @@ public class KeyboardHandler
         /* Survival morphing key handling */
         if (keySurvivalMenu.isPressed())
         {
-            mc.displayGuiScreen(new GuiSurvivalMenu(this.overlay));
+        	//added
+        	if(!Metamorph.proxy.config.disable_gui_open){
+        		mc.displayGuiScreen(new GuiSurvivalMenu(this.overlay));
+        	}
         }
 
         boolean prev = keyPrevMorph.isPressed();

--- a/src/main/java/mchorse/metamorph/config/MetamorphConfig.java
+++ b/src/main/java/mchorse/metamorph/config/MetamorphConfig.java
@@ -62,7 +62,9 @@ public class MetamorphConfig
      * attacked by hostile mobs.
      */
     public boolean disable_morph_disguise;
-
+    
+    //added
+    public boolean disable_gui_open;
     /* End of config options */
 
     /**
@@ -94,6 +96,8 @@ public class MetamorphConfig
         this.disable_morph_animation = this.config.getBoolean("disable_morph_animation", cat, false, "Disables morphing animation", lang + "disable_morph_animation");
         this.disable_morph_disguise = this.config.getBoolean("disable_morph_disguise", cat, false, "Disables the ability of morphs labeled as 'hostile' to avoid being attacked by hostile mobs.", lang + "disable_morph_disguise");
 
+        //added
+        this.disable_gui_open=this.config.getBoolean("disable_gui_open", cat, false, "Disable Metamorph Gui from opening.",lang+"disable_gui_open");
         this.config.getCategory(cat).setComment("General configuration of Metamorph mod");
 
         if (this.config.hasChanged())

--- a/src/main/resources/assets/metamorph/lang/en_US.lang
+++ b/src/main/resources/assets/metamorph/lang/en_US.lang
@@ -75,3 +75,6 @@ morph.category.modded=Morphs from %s
 # Morph builders
 metamorph.builder.nbt=NBT data builder
 metamorph.builder.player=Player morph builder
+
+#added
+metamorph.config.disable_gui_open=Disable Metamorph Gui from opening


### PR DESCRIPTION
added a configuration option to disable metamorph gui screen from opening in either creative or survival modes. This was done, because I have a mod that uses potions to morph players and or mobs using your mod to effect changes, but do not want the players to be able to aquire morph without the potions.

I'll post my morphpotion mod on github.