### PR TITLE
Fix Ender Dragon morph attacking player

### DIFF
--- a/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
+++ b/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
@@ -430,8 +430,7 @@ public class EntityMorph extends AbstractMorph
         entity.ticksExisted = target.ticksExisted;
         /* Fighting with death of entities like zombies */
         entity.setHealth(target.getHealth());
-        /* Prevent drowning sound of squids, guardians, etc... */
-        entity.setAir(300);
+        entity.setAir(cap.getHasSquidAir() ? cap.getSquidAir() : target.getAir());
 
         /* Now goes the code responsible for achieving somewhat riding 
          * support. This is ridiculous... */

--- a/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
+++ b/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
@@ -488,7 +488,12 @@ public class EntityMorph extends AbstractMorph
     {
         if (this.settings.updates)
         {
+            boolean wasInvulnerable = target.isEntityInvulnerable(new DamageSource(""));
+            target.setEntityInvulnerable(true);
+            
             this.entity.onUpdate();
+            
+            target.setEntityInvulnerable(wasInvulnerable);
         }
     }
 

--- a/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
+++ b/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
@@ -343,6 +343,7 @@ public class EntityMorph extends AbstractMorph
         }
 
         /* Update entity */
+        target.setEntityInvulnerable(true);
         this.updateEntity(target);
         entity.deathTime = target.deathTime;
         entity.hurtTime = target.hurtTime;


### PR DESCRIPTION
This PR makes the player invulnerable while the EntityMorph's entity is ticking. I use a similar trick to stop some morph hurt sounds occurring at the wrong time.

I mentioned adding some data so other modders can tell if an entity belongs to a morph. It turned out to not be needed here. The other cases I can think of can easily get the morphing capability. We'll see.