### PR TITLE
Fix NPE on respawn when not in morph

### DIFF
--- a/src/main/java/mchorse/metamorph/capabilities/morphing/Morphing.java
+++ b/src/main/java/mchorse/metamorph/capabilities/morphing/Morphing.java
@@ -323,9 +323,15 @@ public class Morphing implements IMorphing
     public void copy(IMorphing morphing, EntityPlayer player)
     {
         this.acquiredMorphs.addAll(morphing.getAcquiredMorphs());
-        NBTTagCompound morphNBT = new NBTTagCompound();
-        morphing.getCurrentMorph().toNBT(morphNBT);
-        this.setCurrentMorph(MorphManager.INSTANCE.morphFromNBT(morphNBT), player, true);
+        if (morphing.getCurrentMorph() != null) {
+            NBTTagCompound morphNBT = new NBTTagCompound();
+            morphing.getCurrentMorph().toNBT(morphNBT);
+            this.setCurrentMorph(MorphManager.INSTANCE.morphFromNBT(morphNBT), player, true);
+        }
+        else
+        {
+            this.setCurrentMorph(null, player, true);
+        }
     }
 
     @Override


### PR DESCRIPTION
As irony would have it, I finally find a bad bug in code from August 2018, in the PR you just merged, where you can't press the respawn button if you die while not morphed.