### PR TITLE
Fix increasing max health when morphing

### DIFF
--- a/src/main/java/mchorse/metamorph/api/morphs/AbstractMorph.java
+++ b/src/main/java/mchorse/metamorph/api/morphs/AbstractMorph.java
@@ -120,7 +120,7 @@ public abstract class AbstractMorph
      */
     public void morph(EntityLivingBase target)
     {
-        this.lastHealth = target.getMaxHealth();
+        this.lastHealth = (float)target.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getBaseValue();
         this.setHealth(target, this.settings.health);
 
         for (IAbility ability : this.settings.abilities)
@@ -138,7 +138,7 @@ public abstract class AbstractMorph
     public void demorph(EntityLivingBase target)
     {
         /* 20 is default player's health */
-        this.setHealth(target, this.lastHealth < 20 ? 20 : this.lastHealth);
+        this.setHealth(target, this.lastHealth <= 0.0F ? 20.0F : this.lastHealth);
 
         for (IAbility ability : this.settings.abilities)
         {
@@ -224,8 +224,8 @@ public abstract class AbstractMorph
         // We need to retrieve the max health of the target after modifiers are
         // applied
         // to get a sensible value
-        float proportionalHealth = Math.round(target.getMaxHealth() * ratio);
-        target.setHealth(proportionalHealth <= 0 ? 1 : proportionalHealth);
+        float proportionalHealth = target.getMaxHealth() * ratio;
+        target.setHealth(proportionalHealth <= 0.0F ? Float.MIN_VALUE : proportionalHealth);
     }
 
     /**


### PR DESCRIPTION
This fixes the bug where max health would increase if the player has a positive health modifier and demorphs from a mob with lower health than the player.

To see the fix, put this command in a command block, equip the received helmet, and morph to/from a chicken/player:

```
/give @p minecraft:diamond_helmet 1 0 {AttributeModifiers:[{AttributeName:"generic.maxHealth",Name:"generic.maxHealth",Amount:1,Operation:0,UUIDLeast:894654,UUIDMost:2872}]}
```

In master, you'll see max health increasing. In this PR you will not. :D

In addition, this PR also fixes a few other rare edge cases relating to health.