### PR TITLE
Catch exception when deserializing entity for morph

### DIFF
--- a/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
+++ b/src/main/java/mchorse/metamorph/api/morphs/EntityMorph.java
@@ -537,7 +537,11 @@ public class EntityMorph extends AbstractMorph
     {
         EntityLivingBase created = (EntityLivingBase) EntityList.createEntityByIDFromName(name, world);
 
-        created.deserializeNBT(this.entityData);
+        try {
+            created.deserializeNBT(this.entityData);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         created.deathTime = 0;
         created.hurtTime = 0;
         created.limbSwing = 0;


### PR DESCRIPTION
This check should fix a crash when acquiring a morph from a TekTopia villager. It's one of those cases where a modded mob has data that only exists on the server side, which they depend on for NBT serialization.