### PR TITLE
Adds New Attack Type and Fixes Mobs Aggroing Morph Entities

### DIFF
--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -265,7 +265,9 @@ public class MorphHandler
      * Another morphing handler.
      * 
      * This handler is responsible for canceling setting attack target for 
-     * hostile morphs.
+     * hostile morphs.  Also handles any instance where the morph entity
+     * is targeted instead of the player, and shifts the targetting onto
+     * the player.
      */
     @SubscribeEvent
     public void onLivingSetAttackTarget(LivingSetAttackTargetEvent event)
@@ -287,8 +289,11 @@ public class MorphHandler
             {
                 return;
             }
+			
+			AbstractMorph currentMorph = morphing.getCurrentMorph();
 
-            if (morphing.getCurrentMorph().settings.hostile && source.getAttackingEntity() != target)
+            if (morphing.getCurrentMorph().settings.hostile && source.getAttackingEntity() != target && 
+			!(currentMorph instanceof mchorse.metamorph.api.morphs.EntityMorph && ((mchorse.metamorph.api.morphs.EntityMorph) currentMorph).getEntity() == source.getAttackingEntity()))
             {
                 if (source instanceof EntityLiving)
                 {
@@ -296,6 +301,30 @@ public class MorphHandler
                 }
             }
         }
+		else if(target != null)
+		{
+			List playerList = target.world.getEntitiesWithinAABB(EntityPlayer.class, new AxisAlignedBB(target.posX-1,target.posY-1,target.posZ-1,target.posX+1,target.posY+1,target.posZ+1));
+			for(int i = 0; i < playerList.size(); i++)
+			{
+				Object o = playerList.get(i);
+				if(o instanceof EntityPlayer)
+				{
+					EntityPlayer player = (EntityPlayer) o;
+					IMorphing capability = Morphing.get(player);
+					if(capability == null)
+						continue;
+					AbstractMorph currentMorph = capability.getCurrentMorph();
+					if(currentMorph == null)
+						continue;
+					if (currentMorph instanceof mchorse.metamorph.api.morphs.EntityMorph)
+					{
+						mchorse.metamorph.api.morphs.EntityMorph currentEntityMorph = (mchorse.metamorph.api.morphs.EntityMorph) currentMorph;
+						if(currentEntityMorph.getEntity() == target && source instanceof EntityLiving)
+							((EntityLiving) event.getEntity()).setAttackTarget(player);
+					}
+				}
+			}
+		}
     }
 
     /**

--- a/src/main/java/mchorse/vanilla_pack/MetamorphFactory.java
+++ b/src/main/java/mchorse/vanilla_pack/MetamorphFactory.java
@@ -36,6 +36,7 @@ import mchorse.vanilla_pack.actions.Snowball;
 import mchorse.vanilla_pack.actions.Spit;
 import mchorse.vanilla_pack.actions.Teleport;
 import mchorse.vanilla_pack.attacks.KnockbackAttack;
+import mchorse.vanilla_pack.attacks.MobAttack;
 import mchorse.vanilla_pack.attacks.PoisonAttack;
 import mchorse.vanilla_pack.attacks.WitherAttack;
 import mchorse.vanilla_pack.editors.GuiBlockMorph;
@@ -116,9 +117,10 @@ public class MetamorphFactory implements IMorphFactory
         actions.put("teleport", new Teleport());
 
         /* Register default attacks */
+        attacks.put("knockback", new KnockbackAttack());
+        attacks.put("mob", new MobAttack());
         attacks.put("poison", new PoisonAttack());
         attacks.put("wither", new WitherAttack());
-        attacks.put("knockback", new KnockbackAttack());
 
         /* Register main section */
         manager.list.register(new MetamorphSection(this, "entity"));

--- a/src/main/java/mchorse/vanilla_pack/attacks/MobAttack.java
+++ b/src/main/java/mchorse/vanilla_pack/attacks/MobAttack.java
@@ -1,0 +1,41 @@
+package mchorse.vanilla_pack.attacks;
+
+import mchorse.metamorph.api.abilities.IAttackAbility;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
+import mchorse.metamorph.api.morphs.AbstractMorph;
+import mchorse.metamorph.api.morphs.EntityMorph;
+import net.minecraft.entity.player.EntityPlayer;
+import mchorse.metamorph.capabilities.morphing.IMorphing;
+import mchorse.metamorph.capabilities.morphing.Morphing;
+
+/**
+ * Mob attack ability
+ * 
+ * This ability uses the mob's attack instead of the player's.
+ */
+public class MobAttack implements IAttackAbility
+{
+    @Override
+    public void attack(Entity target, EntityLivingBase source)
+    {
+        if (source instanceof EntityPlayer)
+        {
+            EntityPlayer player = (EntityPlayer) source;
+			IMorphing capability = Morphing.get(player);
+			if(capability == null)
+				return;
+			AbstractMorph currentMorph = capability.getCurrentMorph();
+			if(currentMorph == null)
+				return;
+			if(currentMorph instanceof EntityMorph)
+			{
+				EntityMorph currentEntityMorph = (EntityMorph) currentMorph;
+				currentEntityMorph.getEntity(source.world).attackEntityAsMob(target);
+			}
+        }
+    }
+}

--- a/src/main/java/mchorse/vanilla_pack/attacks/MobAttack.java
+++ b/src/main/java/mchorse/vanilla_pack/attacks/MobAttack.java
@@ -3,9 +3,6 @@ package mchorse.vanilla_pack.attacks;
 import mchorse.metamorph.api.abilities.IAttackAbility;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.init.MobEffects;
-import net.minecraft.potion.PotionEffect;
 import mchorse.metamorph.api.morphs.AbstractMorph;
 import mchorse.metamorph.api.morphs.EntityMorph;
 import net.minecraft.entity.player.EntityPlayer;
@@ -15,7 +12,10 @@ import mchorse.metamorph.capabilities.morphing.Morphing;
 /**
  * Mob attack ability
  * 
- * This ability uses the mob's attack instead of the player's.
+ * This ability uses the mob's attack when the player attacks.
+ * Both attacks will go through, taking the highest damage between
+ * the player and the mob, and triggering any special effects the
+ * mob does on attack.
  */
 public class MobAttack implements IAttackAbility
 {

--- a/src/main/java/mchorse/vanilla_pack/morphs/IronGolemMorph.java
+++ b/src/main/java/mchorse/vanilla_pack/morphs/IronGolemMorph.java
@@ -36,17 +36,6 @@ public class IronGolemMorph extends EntityMorph
     }
 
     @Override
-    public void attack(Entity target, EntityLivingBase source)
-    {
-        if (this.entity != null)
-        {
-            this.entity.attackEntityAsMob(target);
-        }
-
-        super.attack(target, source);
-    }
-
-    @Override
     public AbstractMorph create()
     {
         return new IronGolemMorph();

--- a/src/main/resources/assets/metamorph/morphs.json
+++ b/src/main/resources/assets/metamorph/morphs.json
@@ -140,10 +140,11 @@
         "hands": true
     },
     "minecraft:villager_golem": {
-        "attack": "knockback",
+        "abilities": ["prevent_fall", "step_up"],
+	"attack": "mob",
         "health": 100,
-		"hands": true
-    },
+	"hands": true
+    }
     
     "minecraft:blaze": {
         "abilities": ["fly", "fire_proof", "water_allergy"],
@@ -243,10 +244,5 @@
         "action": "fire_breath",
         "health": 200,
         "hostile": true
-    },
-    "minecraft:villager_golem": {
-        "abilities": ["prevent_fall", "step_up"],
-	"attack": "mob",
-        "health": 100
     }
 }

--- a/src/main/resources/assets/metamorph/morphs.json
+++ b/src/main/resources/assets/metamorph/morphs.json
@@ -144,8 +144,7 @@
 	"attack": "mob",
         "health": 100,
 	"hands": true
-    }
-    
+    }.
     "minecraft:blaze": {
         "abilities": ["fly", "fire_proof", "water_allergy"],
         "action": "small_fireball",

--- a/src/main/resources/assets/metamorph/morphs.json
+++ b/src/main/resources/assets/metamorph/morphs.json
@@ -243,5 +243,10 @@
         "action": "fire_breath",
         "health": 200,
         "hostile": true
+    },
+    "minecraft:villager_golem": {
+        "abilities": ["prevent_fall", "step_up"],
+	"attack": "mob",
+        "health": 100
     }
 }

--- a/src/main/resources/assets/metamorph/morphs.json
+++ b/src/main/resources/assets/metamorph/morphs.json
@@ -144,7 +144,7 @@
 	"attack": "mob",
         "health": 100,
 	"hands": true
-    }.
+    },
     "minecraft:blaze": {
         "abilities": ["fly", "fire_proof", "water_allergy"],
         "action": "small_fireball",


### PR DESCRIPTION
Closes #228 

This PR adds in a new attack type, MobAttack.  This does what only the Iron Golem morph did prior and triggers the mobs melee attack when attacking an enemy.  The iron golem has had its knockbackattack removed in favor of the new mobattack, and the built-in mobattack in IronGolemMorph has been removed.  To facilitate this new attack type, the entity targeter will now check if they're about to aggro someone's morph, and if so, target the player instead.  Along with this, the code for preventing mobs aggroing players with hostile morphs has been added to to also check if the player's morph is their current biggest threat, and allow them to aggro if so.

Iron Golems now also have Step Up and Prevent Fall abilities, since both characteristics belong to Iron Golems.