### PR TITLE
Explode Action Considers Creeper's Charged State and E.P.

### DIFF
--- a/src/main/java/mchorse/vanilla_pack/actions/Explode.java
+++ b/src/main/java/mchorse/vanilla_pack/actions/Explode.java
@@ -4,9 +4,12 @@ import javax.annotation.Nullable;
 
 import mchorse.metamorph.api.abilities.IAction;
 import mchorse.metamorph.api.morphs.AbstractMorph;
+import mchorse.metamorph.api.morphs.EntityMorph;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 /**
  * Explode action
@@ -25,8 +28,23 @@ public class Explode implements IAction
         {
             return;
         }
+		
+		int explosionPower = 3;
+		boolean isPowered = false;
+		
+        if (morph instanceof EntityMorph)
+        {
+            EntityLivingBase entity = ((EntityMorph) morph).getEntity();
 
-        target.world.createExplosion(target, target.posX, target.posY, target.posZ, 3, true);
+            if (entity instanceof EntityCreeper)
+            {
+                explosionPower = ReflectionHelper.getPrivateValue(EntityCreeper.class, (EntityCreeper) entity, "explosionRadius", "field_82226_g");
+				isPowered = ((EntityCreeper) entity).getPowered();
+            }
+        }
+
+		float f = isPowered ? 2.0F : 1.0F;
+        target.world.createExplosion(target, target.posX, target.posY, target.posZ, explosionPower * f, true);
 
         if (!(target instanceof EntityPlayer) || (target instanceof EntityPlayer && !((EntityPlayer) target).isCreative()))
         {


### PR DESCRIPTION
Basically, the explosion ability will now consider the explosion power and charged state of the player's morph if said morph is a Creeper.  Allows Charged Creepers to have a bigger boom and for users to have a creeper set off a bigger explosion if they want.  If the player isn't a creeper, the explosion will default to the regular explosion size.