### PR TITLE
Makes Morph Attacks Only Apply On Melee

### DIFF
--- a/src/main/java/mchorse/metamorph/api/MorphHandler.java
+++ b/src/main/java/mchorse/metamorph/api/MorphHandler.java
@@ -244,12 +244,18 @@ public class MorphHandler
     @SubscribeEvent
     public void onPlayerAttack(LivingAttackEvent event)
     {
-        Entity source = event.getSource().getTrueSource();
+        DamageSource source = event.getSource();
+        Entity trueSource = source.getTrueSource();
         Entity target = event.getEntity();
 
-        if (source instanceof EntityPlayer)
+		if(source instanceof EntityDamageSourceIndirect)
+		{
+			return;
+		}
+        
+        if (trueSource instanceof EntityPlayer)
         {
-            EntityPlayer player = (EntityPlayer) source;
+            EntityPlayer player = (EntityPlayer) trueSource;
             IMorphing capability = Morphing.get(player);
 
             if (capability == null || !capability.isMorphed())


### PR DESCRIPTION
Currently, if you're playing as a morph with an on-attack ability, like a cave spider or iron golem, their attack effects will apply whenever the player attacks, regardless of attack type.  For example, if an Iron Golem shoots a bow at someone, the target will be flung up in the air, or in the case of a Cave Spider, the target will be poisoned.  To solve this issue, I've added a check before any attack effects get applied on whether or not the attack was an Indirect one (snowball, arrow, etc...) and if so, don't do the special effect.