### PR TITLE
Update zh_CN.lang

### DIFF
--- a/src/main/resources/assets/metamorph/lang/zh_CN.lang
+++ b/src/main/resources/assets/metamorph/lang/zh_CN.lang
@@ -8,7 +8,7 @@ key.metamorph.action=使用动作
 key.metamorph.creative_menu=打开创造模式伪装菜单
 key.metamorph.selector_menu=打开实体选择器菜单
 key.metamorph.survival_menu=打开生存模式伪装菜单
-key.metamorph.demorph=取消伪装(变回玩家)
+key.metamorph.demorph=取消伪装（变回玩家）
 
 # GUI
 metamorph.gui.body_parts.pick=选择伪装
@@ -16,11 +16,11 @@ metamorph.gui.body_parts.use_target=使用目标
 metamorph.gui.body_parts.parts=身体部分
 metamorph.gui.body_parts.limbs=肢体
 metamorph.gui.body_parts.open=打开身体部分
-metamorph.gui.body_parts.add_tooltip=添加一个新的身体部分...
-metamorph.gui.body_parts.dupe_tooltip=复制当前所选的身体部分...
-metamorph.gui.body_parts.remove_tooltip=移除当前所选的身体部分...
-metamorph.gui.body_parts.copy_tooltip=拷贝所有身体部分...
-metamorph.gui.body_parts.paste_tooltip=粘贴所有拷贝的身体部分...
+metamorph.gui.body_parts.add_tooltip=添加一个新的身体部分……
+metamorph.gui.body_parts.dupe_tooltip=复制当前所选的身体部分……
+metamorph.gui.body_parts.remove_tooltip=移除当前所选的身体部分……
+metamorph.gui.body_parts.copy_tooltip=复制所有身体部分……
+metamorph.gui.body_parts.paste_tooltip=粘贴所有已复制的身体部分……
 
 metamorph.gui.add=添加
 metamorph.gui.remove=移除
@@ -29,11 +29,11 @@ metamorph.gui.acquire=获取
 metamorph.gui.acquired=已获取
 metamorph.gui.close=关闭
 metamorph.gui.search=搜索
-metamorph.gui.no_morph=没有选中伪装...
+metamorph.gui.no_morph=没有选中伪装……
 metamorph.gui.morph_render_error=渲染该伪装时发生错误
 
 metamorph.gui.selectors.title=实体选择器
-metamorph.gui.selectors.tooltip=通过此功能, 您可以为指定名称或指定类型的实体添加伪装...
+metamorph.gui.selectors.tooltip=通过此功能, 您可以为指定名称或指定类型的实体添加伪装……
 metamorph.gui.selectors.add=添加选择器
 metamorph.gui.selectors.remove=移除选择器
 metamorph.gui.selectors.name=名称
@@ -48,7 +48,7 @@ metamorph.gui.morphs.keys.down=向下选择伪装
 metamorph.gui.morphs.keys.right=向右选择伪装
 metamorph.gui.morphs.keys.left=向左选择伪装
 
-metamorph.gui.creative.command=为所选的伪装拷贝 /morph 命令
+metamorph.gui.creative.command=为所选的伪装复制 /morph 命令
 metamorph.gui.creative.edit=编辑
 metamorph.gui.creative.pick=选取
 metamorph.gui.creative.quick=快速编辑
@@ -61,21 +61,21 @@ metamorph.gui.creative.keys.focus=聚焦至搜索框
 metamorph.gui.creative.keys.quick=调出快速编辑菜单
 metamorph.gui.creative.keys.acquire=获取当前所选的伪装
 metamorph.gui.creative.keys.morph=伪装成当前所选的伪装
-metamorph.gui.creative.context.add_global=添加为全局伪装...
-metamorph.gui.creative.context.edit=编辑伪装...
-metamorph.gui.creative.context.add_category=添加新类别
-metamorph.gui.creative.context.rename_category=重命名类别
-metamorph.gui.creative.context.rename_category_modal=为该类别命名...
+metamorph.gui.creative.context.add_global=添加为全局伪装……
+metamorph.gui.creative.context.edit=编辑伪装……
+metamorph.gui.creative.context.add_category=添加新分类
+metamorph.gui.creative.context.rename_category=重命名分类
+metamorph.gui.creative.context.rename_category_modal=为该分类命名……
 metamorph.gui.creative.context.remove_category=移除分类
 metamorph.gui.creative.context.clear_category=清空
-metamorph.gui.creative.context.to_recent=拷贝到最近的伪装
+metamorph.gui.creative.context.to_recent=复制到最近的伪装
 metamorph.gui.creative.context.remove_morph=移除伪装
-metamorph.gui.creative.context.copy=拷贝 NBT
+metamorph.gui.creative.context.copy=复制 NBT
 metamorph.gui.creative.context.paste=粘贴 NBT
-metamorph.gui.creative.context.paste_modal=粘贴或输入您伪装的 NBT 标签...
+metamorph.gui.creative.context.paste_modal=粘贴或输入您伪装的 NBT 标签……
 
 metamorph.gui.survival.title=生存模式伪装菜单
-metamorph.gui.survival.keybind_tooltip=您可以通过此输入框绑定一个快捷键, 这个快捷键会让您变到这个伪装 (当您在菜单或游戏世界中按下时触发)
+metamorph.gui.survival.keybind_tooltip=您可以通过此输入框绑定一个快捷键, 当您在菜单或游戏世界中按下该键时，该键会让您变形到这个伪装。
 metamorph.gui.survival.only_favorites=仅显示收藏
 metamorph.gui.survival.favorite=收藏
 metamorph.gui.survival.keys.category=生存模式伪装菜单
@@ -103,55 +103,55 @@ metamorph.gui.label.shadow=阴影
 metamorph.gui.label.shadow_offset=阴影偏移
 metamorph.gui.label.shadow_color=阴影颜色
 metamorph.gui.label.lighting=发光
-metamorph.gui.label.lighting_tooltip=禁用时, Minecraft 的光照图将不会被应用, 这意味着它会在暗处发光。带有泛光 (Bloom) 效果的光影包, 可以让这个伪装看起来像霓虹灯一样。
+metamorph.gui.label.lighting_tooltip=禁用时,将不会应用Minecraft的光照图, 这意味着它会在暗处发光。带有泛光 (Bloom) 效果的光影包, 可以让这个伪装看起来像霓虹灯一样。
 
 metamorph.gui.edit=编辑
 metamorph.gui.panels.nbt_data=NBT 数据
 metamorph.gui.panels.username=用户名
-metamorph.gui.panels.updating=更新中...
+metamorph.gui.panels.updating=更新中……
 
 metamorph.gui.status.tight_space=此处没有足够的空间来进行伪装
 
 # Config
 metamorph.config.title=Metamorph
 
-metamorph.config.acquiring.title=伪装获取
+metamorph.config.acquiring.title=伪装获取选项
 metamorph.config.acquiring.tooltip=所有与伪装获取方式相关的选项
 
-metamorph.config.acquiring.prevent_ghosts=避免幽灵
-metamorph.config.comments.acquiring.prevent_ghosts=若玩家已有当前被杀死生物的伪装, 则会避免幽灵的生成
-metamorph.config.acquiring.prevent_kill_acquire=避免通过击杀获取
-metamorph.config.comments.acquiring.prevent_kill_acquire=避免通过击杀生物的方式获取伪装
+metamorph.config.acquiring.prevent_ghosts=阻止灵魂生成
+metamorph.config.comments.acquiring.prevent_ghosts=若玩家已有当前被杀死生物的伪装, 则会阻止灵魂生成
+metamorph.config.acquiring.prevent_kill_acquire=阻止通过击杀获取
+metamorph.config.comments.acquiring.prevent_kill_acquire=阻止通过击杀生物的方式获取伪装
 metamorph.config.acquiring.acquire_immediately=立即获取伪装
-metamorph.config.comments.acquiring.acquire_immediately=在玩家杀死实体后立即获取伪装, 而不是生成幽灵
+metamorph.config.comments.acquiring.acquire_immediately=在玩家杀死实体后令玩家立即获取伪装, 而不是生成灵魂
 
 metamorph.config.morphs.title=伪装
 metamorph.config.morphs.tooltip=所有与伪装方式和伪装相关的设置
 
 metamorph.config.morphs.keep_morphs=死后保持伪装
 metamorph.config.comments.morphs.keep_morphs=在玩家死后继续保持伪装
-metamorph.config.morphs.disable_pov=禁用 POV
-metamorph.config.comments.morphs.disable_pov=禁用修改视点高度。应 MorePlayerModels 的要求加入该功能
-metamorph.config.morphs.disable_health=禁用生命值伸缩
-metamorph.config.comments.morphs.disable_health=禁用修改生命值。应意志坚定 (Tough As Nails) 的要求加入该功能
+metamorph.config.morphs.disable_pov=禁用 POV修改
+metamorph.config.comments.morphs.disable_pov=禁用视点高度修改。应 MorePlayerModels 的要求加入该功能
+metamorph.config.morphs.disable_health=禁用生命值修改
+metamorph.config.comments.morphs.disable_health=禁用生命值修改。应意志坚定 (Tough As Nails) 的要求加入该功能
 metamorph.config.morphs.disable_morph_animation=禁用伪装动画
 metamorph.config.comments.morphs.disable_morph_animation=禁用伪装时的动画效果
 metamorph.config.morphs.disable_morph_disguise=禁用伪装无敌
-metamorph.config.comments.morphs.disable_morph_disguise=禁用带有「无敌」技能标签的伪装, 避免被敌对生物攻击
+metamorph.config.comments.morphs.disable_morph_disguise=禁用带有“无敌”技能标签的伪装, 避免被敌对生物攻击
 metamorph.config.morphs.disable_first_person_hand=禁用第一人称手臂
-metamorph.config.comments.morphs.disable_first_person_hand=完全隐藏第一人称手臂的显示
+metamorph.config.comments.morphs.disable_first_person_hand=完全隐藏第一人称手臂
 metamorph.config.morphs.morph_in_tight_spaces=允许在狭窄空间伪装
 metamorph.config.comments.morphs.morph_in_tight_spaces=即使在可能造成窒息时进行伪装, 并允许穿墙
 metamorph.config.morphs.show_morph_idle_sounds=播放伪装的空闲音效
 metamorph.config.comments.morphs.show_morph_idle_sounds=伪装后玩家是否发出实体的空闲音效
 metamorph.config.morphs.pause_gui_in_sp=打开伪装 GUI 后暂停
 metamorph.config.comments.morphs.pause_gui_in_sp=不论是创造模式或生存模式伪装菜单, 在单人模式下打开伪装 GUI 后暂停游戏
-metamorph.config.morphs.max_recent_morphs=最近伪装最大值
+metamorph.config.morphs.max_recent_morphs=最近伪装数量最大值
 metamorph.config.comments.morphs.max_recent_morphs=在被丢弃之前可以添加到伪装菜单中最近的伪装的最大值
 
 # Commands
-metamorph.commands.morph=伪装命令。该命令可以让玩家伪装成指定的伪装。\n\n/morph <username> [morph_name] [data_tag]
-metamorph.commands.acquire_morph=获取伪装命令。该命令可以将伪装发送到指定玩家的已获取伪装列表。\n\n/morph <username> <morph_name> [data_tag]
+metamorph.commands.morph=伪装命令。该命令可以让玩家伪装成指定的伪装。\n\n/morph <玩家名> [伪装名称] [数据标签]
+metamorph.commands.acquire_morph=获取伪装命令。该命令可以将伪装发送到指定玩家的已获取伪装列表。\n\n/morph <玩家名> <伪装名称> [数据标签]
 metamorph.commands.metamorph=Metamorph 服务器命令。该命令可用于在服务端管理 Metamorph 的东西。\n\n/metamorph reload <blacklist|morphs> - 重新载入 Metamorph 的黑名单或伪装配置
 
 metamorph.error.morph.not_player=实体 %s 不是玩家!


### PR DESCRIPTION
Changed the translations of "copy" from "拷贝" to "复制"
The translations of "category" is now unified as "分类"
Added some missing sentence components.
Ellipsis is changed from English to Chinese（from "..." to "……")
Translated command grammar tips.
The translations of "prevent" is changed from "避免" to "阻止"